### PR TITLE
Add support for newer kernels (e.g. 5.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Module.markers
 Module.symvers
 modules.order
 .tmp_versions/
+*.mod

--- a/mrfcommon.c
+++ b/mrfcommon.c
@@ -896,13 +896,8 @@ ssize_t ev_write(struct file *filp, const char __user *buf, size_t count,
   return retval;
 }
 
-#ifdef HAVE_UNLOCKED_IOCTL
 long ev_unlocked_ioctl(struct file *filp,
 	     unsigned int cmd, unsigned long arg)
-#else
-int ev_ioctl(struct inode *inode, struct file *filp,
-	     unsigned int cmd, unsigned long arg)
-#endif
 {
   struct mrf_dev *ev_device = (struct mrf_dev *) filp->private_data;
   int ret = 0;

--- a/mrfcommon.c
+++ b/mrfcommon.c
@@ -910,9 +910,9 @@ long ev_unlocked_ioctl(struct file *filp,
 
   /* Check access */
   if (_IOC_DIR(cmd) & _IOC_READ)
-    ret = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+    ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
   else if (_IOC_DIR(cmd) & _IOC_WRITE)
-    ret = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+    ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
   if (ret)
     return -EFAULT;
 

--- a/mrfevg.c
+++ b/mrfevg.c
@@ -180,7 +180,7 @@ static int pci_evg_probe(struct pci_dev *pcidev, const struct pci_device_id *dev
 				 - ev_device->BAR_start[i] + 1,
 				 DEVICE_NAME) != NULL)
 	    {
-	      ev_device->BAR_mmapped[i] = ioremap_nocache(ev_device->BAR_start[i],
+	      ev_device->BAR_mmapped[i] = ioremap(ev_device->BAR_start[i],
 							  ev_device->BAR_end[i] -
 							  ev_device->BAR_start[i] + 1);
 	      printk(KERN_WARNING DEVICE_NAME ":BAR%d start %08x end %08x mmaped %08x\n", i,

--- a/mrfevg.c
+++ b/mrfevg.c
@@ -45,11 +45,7 @@ static struct file_operations evg_fops = {
   .owner = THIS_MODULE,
   .read = ev_read,
   .write = ev_write,
-#ifdef HAVE_UNLOCKED_IOCTL
   .unlocked_ioctl = ev_unlocked_ioctl,
-#else
-  .ioctl = ev_ioctl,
-#endif
   .open = ev_open,
   .release = ev_release,
   .fasync = ev_fasync,

--- a/mrfevr.c
+++ b/mrfevr.c
@@ -210,7 +210,7 @@ static int pci_evr_probe(struct pci_dev *pcidev, const struct pci_device_id *dev
 	  if (request_mem_region(ev_device->BAR_start[i], ev_device->BAR_end[i]
 				 - ev_device->BAR_start[i] + 1,
 				 DEVICE_NAME) != NULL)
-	    ev_device->BAR_mmapped[i] = ioremap_nocache(ev_device->BAR_start[i],
+	    ev_device->BAR_mmapped[i] = ioremap(ev_device->BAR_start[i],
 							ev_device->BAR_end[i] -
 							ev_device->BAR_start[i] + 1);
 	  printk(KERN_WARNING DEVICE_NAME ":BAR%d start %08x end %08x, mmap %08x\n", i,

--- a/mrfevr.c
+++ b/mrfevr.c
@@ -47,11 +47,7 @@ static struct file_operations evr_fops = {
   .owner = THIS_MODULE,
   .read = ev_read,
   .write = ev_write,
-#ifdef HAVE_UNLOCKED_IOCTL
   .unlocked_ioctl = ev_unlocked_ioctl,
-#else
-  .ioctl = ev_ioctl,
-#endif
   .open = ev_open,
   .release = ev_release,
   .fasync = ev_fasync,

--- a/pci_mrfev.h
+++ b/pci_mrfev.h
@@ -147,13 +147,8 @@ ssize_t ev_read(struct file *filp, char __user *buf, size_t count,
 		loff_t *f_pos);
 ssize_t ev_write(struct file *filp, const char __user *buf, size_t count,
 		 loff_t *f_pos);
-#ifdef HAVE_UNLOCKED_IOCTL
 long ev_unlocked_ioctl(struct file *filp,
 		       unsigned int cmd, unsigned long arg);
-#else
-int ev_ioctl(struct inode *inode, struct file *filp,
-	     unsigned int cmd, unsigned long arg);
-#endif
 int ev_fasync(int fd, struct file *filp, int mode);
 int ev_remap_mmap(struct file *filp, struct vm_area_struct *vma);
 #if LINUX_VERSION_CODE > (0x020619)


### PR DESCRIPTION
I have tested this on Debian 11 with kernel 5.10.

Most commits have a reference to changes in the kernel so they can be checked if this works with kernel versions lower than 5.10.