### PR TITLE
Improve compatibility with recent kernel versions

### DIFF
--- a/mrfcommon.c
+++ b/mrfcommon.c
@@ -41,6 +41,12 @@ MODULE_LICENSE("GPL");
 
 #define LATTICE_IRQ 1
 
+#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+#define mrf_access_ok(type, addr, size) access_ok(addr, size)
+#else
+#define mrf_access_ok(type, addr, size) access_ok(type, addr, size)
+#endif // KERNEL_VERSION(5, 0, 0)
+
 struct mrf_dev mrf_devices[MAX_MRF_DEVICES];
 
 int ev_assign_irq(struct mrf_dev *ev_device);
@@ -915,9 +921,9 @@ int ev_ioctl(struct inode *inode, struct file *filp,
 
   /* Check access */
   if (_IOC_DIR(cmd) & _IOC_READ)
-    ret = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+    ret = !mrf_access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
   else if (_IOC_DIR(cmd) & _IOC_WRITE)
-    ret = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+    ret = !mrf_access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
   if (ret)
     return -EFAULT;
 

--- a/pci_mrfev.h
+++ b/pci_mrfev.h
@@ -49,6 +49,23 @@
 #define DEVICE_EV     3
 #define DEVICE_LAST   3
 
+/*
+  Starting with kernel 5.6, ioremap_nocache is not defined by the kernel headers
+  any longer. Before, it was defined as an alias for ioremap, which changed its
+  caching behavior a long time ago.
+*/
+#if KERNEL_VERSION(5, 6, 0) <= LINUX_VERSION_CODE
+#define ioremap_nocache ioremap
+#endif
+
+/*
+  Starting with kernel 5.9, HAVE_UNLOCKED_IOCTL is not defined by the kernel
+  headers any longer.
+*/
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#define HAVE_UNLOCKED_IOCTL 1
+#endif
+
 /* Define the maximum number of words in EEPROM */
 #define EEPROM_MAX_WORDS            256
 


### PR DESCRIPTION
There have been API changes in kernel versions 5.0, 5.6, and 5.9 that necessitate code changes in the kernel module in order to make it compile with recent kernels.

With these changes, the kernel module should compile with kernels up to version 6.2.