### PR TITLE
Fix compatibility with Linux kernel >= 6.4

### DIFF
--- a/mrfevg.c
+++ b/mrfevg.c
@@ -339,7 +339,7 @@ static int __init pci_evg_init(void)
   memset(mrf_devices, 0, sizeof(struct mrf_dev)*MAX_MRF_DEVICES);
 
   printk(KERN_ALERT "Event Generator PCI/PCIe driver init.\n");
-  mrf_evg_class = class_create(THIS_MODULE, DEVICE_NAME);
+  mrf_evg_class = mrf_class_create(THIS_MODULE, DEVICE_NAME);
   if (IS_ERR(mrf_evg_class))
     printk(KERN_WARNING DEVICE_NAME ": cannot register device class.\n");
   return pci_register_driver(&evg_driver);    

--- a/mrfevr.c
+++ b/mrfevr.c
@@ -409,7 +409,7 @@ static int __init pci_evr_init(void)
   memset(mrf_devices, 0, sizeof(struct mrf_dev)*MAX_MRF_DEVICES);
 
   printk(KERN_ALERT "Event Receiver PCI/PCIe driver init.\n");
-  mrf_evr_class = class_create(THIS_MODULE, DEVICE_NAME);
+  mrf_evr_class = mrf_class_create(THIS_MODULE, DEVICE_NAME);
   if (IS_ERR(mrf_evr_class))
     printk(KERN_WARNING DEVICE_NAME ": cannot register device class.\n");
   return pci_register_driver(&evr_driver);    

--- a/pci_mrfev.h
+++ b/pci_mrfev.h
@@ -49,6 +49,17 @@
 #define DEVICE_EV     3
 #define DEVICE_LAST   3
 
+/*
+  In old kernel versions, class_create takes two arguments. Starting with
+  kernel 6.4, it only takes a single argument.
+*/
+#if KERNEL_VERSION(6, 4, 0) <= LINUX_VERSION_CODE
+#define mrf_class_create(module_info, device_name) class_create(device_name)
+#else
+#define mrf_class_create(module_info, device_name) \
+  class_create(module_info, device_name)
+#endif
+
 /* Define the maximum number of words in EEPROM */
 #define EEPROM_MAX_WORDS            256
 


### PR DESCRIPTION
The signature of the `class_create` function changed in Linux 6.4. Now, it only takes a single argument (the device name) instead of two arguments.

This PR adds compatibilty with these kernel versions by omitting the first argument (`THIS_MODULE`) when compiling for Linux >= 6.4.